### PR TITLE
feat: Add cachekv.Store.Unset() and gaskv.Store.GetParent() methods

### DIFF
--- a/store/cachekv/store.go
+++ b/store/cachekv/store.go
@@ -81,6 +81,16 @@ func (store *Store) Set(key []byte, value []byte) {
 	store.setCacheValue(key, value, false, true)
 }
 
+// Unset removes the key from the cache, removing any write or delete for the key.
+func (store *Store) Unset(key []byte) {
+	keyStr := conv.UnsafeBytesToStr(key)
+
+	delete(store.cache, keyStr)
+	delete(store.deleted, keyStr)
+	delete(store.unsortedCache, keyStr)
+	store.sortedCache.Delete(key)
+}
+
 // Has implements types.KVStore.
 func (store *Store) Has(key []byte) bool {
 	value := store.Get(key)

--- a/store/gaskv/store.go
+++ b/store/gaskv/store.go
@@ -31,6 +31,11 @@ func (gs *Store) GetStoreType() types.StoreType {
 	return gs.parent.GetStoreType()
 }
 
+// GetParent returns the parent KVStore.
+func (gs *Store) GetParent() types.KVStore {
+	return gs.parent
+}
+
 // Implements KVStore.
 func (gs *Store) Get(key []byte) (value []byte) {
 	gs.gasMeter.ConsumeGas(gs.gasConfig.ReadCostFlat, types.GasReadCostFlatDesc)

--- a/store/gaskv/store_test.go
+++ b/store/gaskv/store_test.go
@@ -118,3 +118,11 @@ func TestGasKVStoreOutOfGasIterator(t *testing.T) {
 	iterator.Next()
 	require.Panics(t, func() { iterator.Value() }, "Expected out-of-gas")
 }
+
+func TestGasKVStoreGetParent(t *testing.T) {
+	mem := dbadapter.Store{DB: dbm.NewMemDB()}
+	meter := types.NewGasMeter(10000)
+
+	st := gaskv.NewStore(mem, meter, types.KVGasConfig())
+	require.Equal(t, mem, st.GetParent())
+}


### PR DESCRIPTION
Required for use in https://github.com/Kava-Labs/ethermint/pull/39 to support removal of no-op contract state writes