### PR TITLE
deps: use patched iavl v1.2 version v1.2.0-kava.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -195,6 +195,7 @@ replace (
 	// Use cometbft fork of tendermint
 	github.com/cometbft/cometbft => github.com/kava-labs/cometbft v0.37.4-kava.1
 	github.com/cometbft/cometbft-db => github.com/kava-labs/cometbft-db v0.9.1-kava.1
+	github.com/cosmos/iavl => github.com/kava-labs/iavl v1.2.0-kava.1
 	// dgrijalva/jwt-go is deprecated and doesn't receive security updates.
 	// TODO: remove it: https://github.com/cosmos/cosmos-sdk/issues/13134
 	github.com/dgrijalva/jwt-go => github.com/golang-jwt/jwt/v4 v4.4.2

--- a/go.sum
+++ b/go.sum
@@ -348,8 +348,6 @@ github.com/cosmos/gogogateway v1.2.0/go.mod h1:iQpLkGWxYcnCdz5iAdLcRBSw3h7NXeOkZ
 github.com/cosmos/gogoproto v1.4.2/go.mod h1:cLxOsn1ljAHSV527CHOtaIP91kK6cCrZETRBrkzItWU=
 github.com/cosmos/gogoproto v1.4.10 h1:QH/yT8X+c0F4ZDacDv3z+xE3WU1P1Z3wQoLMBRJoKuI=
 github.com/cosmos/gogoproto v1.4.10/go.mod h1:3aAZzeRWpAwr+SS/LLkICX2/kDFyaYVzckBDzygIxek=
-github.com/cosmos/iavl v1.0.0 h1:bw6t0Mv/mVCJvlMTOPHWLs5uUE3BRBfVWCRelOzl+so=
-github.com/cosmos/iavl v1.0.0/go.mod h1:CmTGqMnRnucjxbjduneZXT+0vPgNElYvdefjX2q9tYc=
 github.com/cosmos/ics23/go v0.10.0 h1:iXqLLgp2Lp+EdpIuwXTYIQU+AiHj9mOC2X9ab++bZDM=
 github.com/cosmos/ics23/go v0.10.0/go.mod h1:ZfJSmng/TBNTBkFemHHHj5YY7VAU/MBU980F4VU1NG0=
 github.com/cosmos/keyring v1.2.0 h1:8C1lBP9xhImmIabyXW4c3vFjjLiBdGCmfLUfeZlV1Yo=
@@ -707,6 +705,8 @@ github.com/kava-labs/cometbft v0.37.4-kava.1 h1:QRuyBieWdUBpe4pcXgzu1SdMH2lkTaqX
 github.com/kava-labs/cometbft v0.37.4-kava.1/go.mod h1:Cmg5Hp4sNpapm7j+x0xRyt2g0juQfmB752ous+pA0G8=
 github.com/kava-labs/cometbft-db v0.9.1-kava.1 h1:0KmSPdXYdRp6TsgKuMxRnMZCMEGC5ysIVjuJddYr4tw=
 github.com/kava-labs/cometbft-db v0.9.1-kava.1/go.mod h1:iliyWaoV0mRwBJoizElCwwRA9Tf7jZJOURcRZF9m60U=
+github.com/kava-labs/iavl v1.2.0-kava.1 h1:HPme3nVrR25XshEFDckMg6fp0tVfpAjTi32/5Iiyuzk=
+github.com/kava-labs/iavl v1.2.0-kava.1/go.mod h1:HidWWLVAtODJqFD6Hbne2Y0q3SdxByJepHUOeoH4LiI=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/store/cache/cache_test.go
+++ b/store/cache/cache_test.go
@@ -7,6 +7,7 @@ import (
 	"cosmossdk.io/log"
 	dbm "github.com/cometbft/cometbft-db"
 	"github.com/cosmos/iavl"
+	iavldb "github.com/cosmos/iavl/db"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cosmos/cosmos-sdk/store/cache"
@@ -21,7 +22,7 @@ func TestGetOrSetStoreCache(t *testing.T) {
 	mngr := cache.NewCommitKVStoreCacheManager(cache.DefaultCommitKVStoreCacheSize)
 
 	sKey := types.NewKVStoreKey("test")
-	tree := iavl.NewMutableTree(db, 100, false, log.NewNopLogger())
+	tree := iavl.NewMutableTree(iavldb.NewWrapper(db), 100, false, log.NewNopLogger())
 	store := iavlstore.UnsafeNewStore(tree)
 	store2 := mngr.GetStoreCache(sKey, store)
 
@@ -34,7 +35,7 @@ func TestUnwrap(t *testing.T) {
 	mngr := cache.NewCommitKVStoreCacheManager(cache.DefaultCommitKVStoreCacheSize)
 
 	sKey := types.NewKVStoreKey("test")
-	tree := iavl.NewMutableTree(db, 100, false, log.NewNopLogger())
+	tree := iavl.NewMutableTree(iavldb.NewWrapper(db), 100, false, log.NewNopLogger())
 	store := iavlstore.UnsafeNewStore(tree)
 	_ = mngr.GetStoreCache(sKey, store)
 
@@ -47,7 +48,7 @@ func TestStoreCache(t *testing.T) {
 	mngr := cache.NewCommitKVStoreCacheManager(cache.DefaultCommitKVStoreCacheSize)
 
 	sKey := types.NewKVStoreKey("test")
-	tree := iavl.NewMutableTree(db, 100, false, log.NewNopLogger())
+	tree := iavl.NewMutableTree(iavldb.NewWrapper(db), 100, false, log.NewNopLogger())
 	store := iavlstore.UnsafeNewStore(tree)
 	kvStore := mngr.GetStoreCache(sKey, store)
 
@@ -73,7 +74,7 @@ func TestReset(t *testing.T) {
 	mngr := cache.NewCommitKVStoreCacheManager(cache.DefaultCommitKVStoreCacheSize)
 
 	sKey := types.NewKVStoreKey("test")
-	tree := iavl.NewMutableTree(db, 100, false, log.NewNopLogger())
+	tree := iavl.NewMutableTree(iavldb.NewWrapper(db), 100, false, log.NewNopLogger())
 	store := iavlstore.UnsafeNewStore(tree)
 	store2 := mngr.GetStoreCache(sKey, store)
 
@@ -93,7 +94,7 @@ func TestCacheWrap(t *testing.T) {
 	mngr := cache.NewCommitKVStoreCacheManager(cache.DefaultCommitKVStoreCacheSize)
 
 	sKey := types.NewKVStoreKey("test")
-	tree := iavl.NewMutableTree(db, 100, false, log.NewNopLogger())
+	tree := iavl.NewMutableTree(iavldb.NewWrapper(db), 100, false, log.NewNopLogger())
 	store := iavlstore.UnsafeNewStore(tree)
 
 	cacheWrapper := mngr.GetStoreCache(sKey, store).CacheWrap()

--- a/store/iavl/store.go
+++ b/store/iavl/store.go
@@ -13,6 +13,7 @@ import (
 	tmcrypto "github.com/cometbft/cometbft/proto/tendermint/crypto"
 	ics23 "github.com/confio/ics23/go"
 	"github.com/cosmos/iavl"
+	iavldb "github.com/cosmos/iavl/db"
 
 	"github.com/cosmos/cosmos-sdk/store/cachekv"
 	pruningtypes "github.com/cosmos/cosmos-sdk/store/pruning/types"
@@ -54,7 +55,8 @@ func LoadStore(db dbm.DB, logger log.Logger, key types.StoreKey, id types.Commit
 // provided DB. An error is returned if the version fails to load, or if called with a positive
 // version on an empty tree.
 func LoadStoreWithInitialVersion(db dbm.DB, logger log.Logger, key types.StoreKey, id types.CommitID, lazyLoading bool, initialVersion uint64, cacheSize int, disableFastNode bool) (types.CommitKVStore, error) {
-	tree := iavl.NewMutableTree(wrapper.NewCosmosDB(db), cacheSize, disableFastNode, clog.NewNopLogger(), iavl.InitialVersionOption(initialVersion))
+	cosmosdb := wrapper.NewCosmosDB(db)
+	tree := iavl.NewMutableTree(iavldb.NewWrapper(cosmosdb), cacheSize, disableFastNode, clog.NewNopLogger(), iavl.InitialVersionOption(initialVersion))
 
 	isUpgradeable, err := tree.IsUpgradeable()
 	if err != nil {

--- a/store/iavl/store_test.go
+++ b/store/iavl/store_test.go
@@ -13,6 +13,7 @@ import (
 	abci "github.com/cometbft/cometbft/abci/types"
 	cmlog "github.com/cometbft/cometbft/libs/log"
 	"github.com/cosmos/iavl"
+	iavldb "github.com/cosmos/iavl/db"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cosmos/cosmos-sdk/store/types"
@@ -37,7 +38,7 @@ func randBytes(numBytes int) []byte {
 // make a tree with data from above and save it
 func newAlohaTree(t *testing.T, db dbm.DB) (*iavl.MutableTree, types.CommitID) {
 	dbt := wrapper.NewCosmosDB(db)
-	tree := iavl.NewMutableTree(dbt, cacheSize, false, log.NewNopLogger())
+	tree := iavl.NewMutableTree(iavldb.NewWrapper(dbt), cacheSize, false, log.NewNopLogger())
 
 	for k, v := range treeData {
 		tree.Set([]byte(k), []byte(v))
@@ -283,7 +284,7 @@ func TestIAVLIterator(t *testing.T) {
 
 func TestIAVLReverseIterator(t *testing.T) {
 	db := wrapper.NewCosmosDB(dbm.NewMemDB())
-	tree := iavl.NewMutableTree(db, cacheSize, false, log.NewNopLogger())
+	tree := iavl.NewMutableTree(iavldb.NewWrapper(db), cacheSize, false, log.NewNopLogger())
 
 	iavlStore := UnsafeNewStore(tree)
 
@@ -315,7 +316,7 @@ func TestIAVLReverseIterator(t *testing.T) {
 
 func TestIAVLPrefixIterator(t *testing.T) {
 	db := wrapper.NewCosmosDB(dbm.NewMemDB())
-	tree := iavl.NewMutableTree(db, cacheSize, false, log.NewNopLogger())
+	tree := iavl.NewMutableTree(iavldb.NewWrapper(db), cacheSize, false, log.NewNopLogger())
 
 	iavlStore := UnsafeNewStore(tree)
 
@@ -378,7 +379,7 @@ func TestIAVLPrefixIterator(t *testing.T) {
 
 func TestIAVLReversePrefixIterator(t *testing.T) {
 	db := wrapper.NewCosmosDB(dbm.NewMemDB())
-	tree := iavl.NewMutableTree(db, cacheSize, false, log.NewNopLogger())
+	tree := iavl.NewMutableTree(iavldb.NewWrapper(db), cacheSize, false, log.NewNopLogger())
 
 	iavlStore := UnsafeNewStore(tree)
 
@@ -445,7 +446,7 @@ func nextVersion(iavl *Store) {
 
 func TestIAVLNoPrune(t *testing.T) {
 	db := wrapper.NewCosmosDB(dbm.NewMemDB())
-	tree := iavl.NewMutableTree(db, cacheSize, false, log.NewNopLogger())
+	tree := iavl.NewMutableTree(iavldb.NewWrapper(db), cacheSize, false, log.NewNopLogger())
 
 	iavlStore := UnsafeNewStore(tree)
 	nextVersion(iavlStore)
@@ -463,7 +464,7 @@ func TestIAVLNoPrune(t *testing.T) {
 
 func TestIAVLStoreQuery(t *testing.T) {
 	db := wrapper.NewCosmosDB(dbm.NewMemDB())
-	tree := iavl.NewMutableTree(db, cacheSize, false, log.NewNopLogger())
+	tree := iavl.NewMutableTree(iavldb.NewWrapper(db), cacheSize, false, log.NewNopLogger())
 
 	iavlStore := UnsafeNewStore(tree)
 
@@ -566,7 +567,7 @@ func BenchmarkIAVLIteratorNext(b *testing.B) {
 	b.ReportAllocs()
 	db := wrapper.NewCosmosDB(dbm.NewMemDB())
 	treeSize := 1000
-	tree := iavl.NewMutableTree(db, cacheSize, false, log.NewNopLogger())
+	tree := iavl.NewMutableTree(iavldb.NewWrapper(db), cacheSize, false, log.NewNopLogger())
 
 	for i := 0; i < treeSize; i++ {
 		key := randBytes(4)
@@ -600,7 +601,7 @@ func TestSetInitialVersion(t *testing.T) {
 			"works with a mutable tree",
 			func(db *dbm.MemDB) *Store {
 				dbt := wrapper.NewCosmosDB(db)
-				tree := iavl.NewMutableTree(dbt, cacheSize, false, log.NewNopLogger())
+				tree := iavl.NewMutableTree(iavldb.NewWrapper(dbt), cacheSize, false, log.NewNopLogger())
 				store := UnsafeNewStore(tree)
 
 				return store
@@ -610,7 +611,7 @@ func TestSetInitialVersion(t *testing.T) {
 			"throws error on immutable tree",
 			func(db *dbm.MemDB) *Store {
 				dbt := wrapper.NewCosmosDB(db)
-				tree := iavl.NewMutableTree(dbt, cacheSize, false, log.NewNopLogger())
+				tree := iavl.NewMutableTree(iavldb.NewWrapper(dbt), cacheSize, false, log.NewNopLogger())
 				store := UnsafeNewStore(tree)
 				_, version, err := store.tree.SaveVersion()
 				require.NoError(t, err)

--- a/store/iavl/tree_test.go
+++ b/store/iavl/tree_test.go
@@ -8,13 +8,14 @@ import (
 	dbm "github.com/cometbft/cometbft-db"
 	"github.com/cosmos/cosmos-sdk/store/wrapper"
 	"github.com/cosmos/iavl"
+	iavldb "github.com/cosmos/iavl/db"
 	"github.com/stretchr/testify/require"
 )
 
 func TestImmutableTreePanics(t *testing.T) {
 	t.Parallel()
 	db := wrapper.NewCosmosDB(dbm.NewMemDB())
-	immTree := iavl.NewImmutableTree(db, 100, false, log.NewNopLogger())
+	immTree := iavl.NewImmutableTree(iavldb.NewWrapper(db), 100, false, log.NewNopLogger())
 	it := &immutableTree{immTree}
 	require.Panics(t, func() { it.Set([]byte{}, []byte{}) })
 	require.Panics(t, func() { it.Remove([]byte{}) })

--- a/store/prefix/store_test.go
+++ b/store/prefix/store_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	tiavl "github.com/cosmos/iavl"
+	iavldb "github.com/cosmos/iavl/db"
 
 	"github.com/cosmos/cosmos-sdk/store/dbadapter"
 	"github.com/cosmos/cosmos-sdk/store/gaskv"
@@ -92,7 +93,7 @@ func testPrefixStore(t *testing.T, baseStore types.KVStore, prefix []byte) {
 
 func TestIAVLStorePrefix(t *testing.T) {
 	db := wrapper.NewCosmosDB(dbm.NewMemDB())
-	tree := tiavl.NewMutableTree(db, cacheSize, false, log.NewNopLogger())
+	tree := tiavl.NewMutableTree(iavldb.NewWrapper(db), cacheSize, false, log.NewNopLogger())
 	iavlStore := iavl.UnsafeNewStore(tree)
 
 	testPrefixStore(t, iavlStore, []byte("test"))


### PR DESCRIPTION
iavl v1.1 -> v1.2 replaces the use of cosmos-db with a type included with iavl (to convert use `iavldb.NewWrapper`)

includes patches for:
* fixed initial version of added KVStores
* expose DeleteVersionsFrom on MutableTree

patches are published here:
https://github.com/Kava-Labs/kava-patches/tree/19bf1a78805a33fe7a27044f2b03dc3ce1d90392/iavl-v1.2
