### PR TITLE
feat: add --unsafe-remove-modules flag to Rollback cmd

### DIFF
--- a/server/rollback.go
+++ b/server/rollback.go
@@ -8,11 +8,13 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/server/types"
+	"github.com/cosmos/cosmos-sdk/store/rootmulti"
 )
 
 // NewRollbackCmd creates a command to rollback tendermint and multistore state by one height.
 func NewRollbackCmd(appCreator types.AppCreator, defaultNodeHome string) *cobra.Command {
 	var removeBlock bool
+	moduleKeysToDelete := make([]string, 0)
 
 	cmd := &cobra.Command{
 		Use:   "rollback",
@@ -39,6 +41,17 @@ application.
 			if err != nil {
 				return fmt.Errorf("failed to rollback tendermint state: %w", err)
 			}
+
+			// for rolling back upgrades that add modules, we must first forcibly delete those.
+			// otherwise, the rollback will panic because no version of new modules will exist.
+			store := app.CommitMultiStore().(*rootmulti.Store)
+			for _, key := range moduleKeysToDelete {
+				fmt.Printf("deleting KVStore with key %s\n", key)
+				if err := store.DeleteKVStore(key); err != nil {
+					return err
+				}
+			}
+
 			// rollback the multistore
 
 			if err := app.CommitMultiStore().RollbackToVersion(height); err != nil {
@@ -52,5 +65,6 @@ application.
 
 	cmd.Flags().String(flags.FlagHome, defaultNodeHome, "The application home directory")
 	cmd.Flags().BoolVar(&removeBlock, "hard", false, "remove last block as well as state")
+	cmd.Flags().StringSliceVar(&moduleKeysToDelete, "unsafe-remove-modules", []string{}, "force delete KV stores with the provided prefix. useful for rolling back an upgrade that adds a module")
 	return cmd
 }

--- a/server/rollback.go
+++ b/server/rollback.go
@@ -46,8 +46,8 @@ application.
 			// otherwise, the rollback will panic because no version of new modules will exist.
 			store := app.CommitMultiStore().(*rootmulti.Store)
 			for _, key := range moduleKeysToDelete {
-				fmt.Printf("deleting KVStore with key %s\n", key)
-				if err := store.DeleteKVStore(key); err != nil {
+				fmt.Printf("deleting latest version of KVStore with key %s\n", key)
+				if err := store.DeleteLatestVersion(key); err != nil {
 					return err
 				}
 			}

--- a/store/iavl/store.go
+++ b/store/iavl/store.go
@@ -229,6 +229,11 @@ func (st *Store) DeleteVersionsTo(version int64) error {
 	return st.tree.DeleteVersionsTo(version)
 }
 
+// DeleteVersionsFrom deletes from the given version upwards
+func (st *Store) DeleteVersionsFrom(version int64) error {
+	return st.tree.DeleteVersionsFrom(version)
+}
+
 // LoadVersionForOverwriting attempts to load a tree at a previously committed
 // version, or the latest version below it. Any versions greater than targetVersion will be deleted.
 func (st *Store) LoadVersionForOverwriting(targetVersion int64) (int64, error) {

--- a/store/iavl/store.go
+++ b/store/iavl/store.go
@@ -229,7 +229,7 @@ func (st *Store) DeleteVersionsTo(version int64) error {
 	return st.tree.DeleteVersionsTo(version)
 }
 
-// DeleteVersionsFrom deletes from the given version upwards
+// DeleteVersionsFrom deletes from the given version upwards form the MutableTree.
 func (st *Store) DeleteVersionsFrom(version int64) error {
 	return st.tree.DeleteVersionsFrom(version)
 }

--- a/store/iavl/tree.go
+++ b/store/iavl/tree.go
@@ -30,6 +30,7 @@ type (
 		WorkingHash() []byte
 		VersionExists(version int64) bool
 		DeleteVersionsTo(version int64) error
+		DeleteVersionsFrom(version int64) error
 		GetVersioned(key []byte, version int64) ([]byte, error)
 		GetImmutable(version int64) (*iavl.ImmutableTree, error)
 		SetInitialVersion(version uint64)
@@ -65,6 +66,10 @@ func (it *immutableTree) SaveVersion() ([]byte, int64, error) {
 
 func (it *immutableTree) DeleteVersionsTo(_ int64) error {
 	panic("cannot call 'DeleteVersionsTo' on an immutable IAVL tree")
+}
+
+func (it *immutableTree) DeleteVersionsFrom(_ int64) error {
+	panic("cannot call 'DeleteVersionsFrom' on an immutable IAVL tree")
 }
 
 func (it *immutableTree) SetInitialVersion(_ uint64) {


### PR DESCRIPTION
* adds public `DeleteLatestVersion` method on root multistore
  * this calls recently exposed `DeleteVersionsFrom` method on iavl store which writes deletion of versions from given version upwards to disk.
  * interface for IAVL tree was extended to include this. Requires iavl `v1.2.0-kava.1`.
* rollback command accepts list of store keys names to forcibly delete

this is useful for rolling back an upgrade that adds modules.
rollbacks are performed by loading & committing the previous version.
without this new functionality, the rollback will fail because no store
version will exist for modules added during the upgrade.

to properly rollback the state, pass in a list of the added module names
and they will be completely removed before the rollback of pre-existing
modules takes place:
```
kava rollback --unsafe-remove-modules mynewmodule,othernewmodule
```